### PR TITLE
24.08.23 redis 셋팅 및 게시글 불러올 때 캐싱 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     //AOP(Aspect-Oriented Programming) 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-aop'
-
+    //redis 의존선 추가
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ac/su/community/board/BoardController.java
+++ b/src/main/java/com/ac/su/community/board/BoardController.java
@@ -9,6 +9,7 @@ import com.ac.su.community.post.PostRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +28,13 @@ public class BoardController {
     private final ClubRepository clubRepository;
     private final AttachmentRepository attachmentRepository;
 
+    // 캐싱을 위한 어노테이션. 이 메서드의 결과를 캐시에 저장하고,
+    // 동일한 인자로 호출될 때 캐시에서 결과를 가져옴
+    @Cacheable(
+            cacheNames = "getBoards", // 캐시의 이름. 다른 캐시와 구분하기 위해 사용됨
+            key = "'boards:type:' + #type", // 캐시의 키를 정의. 여기서는 페이지와 사이즈를 포함한 문자열로 키를 생성함
+            cacheManager = "boardCacheManager" // 사용할 캐시 매니저를 지정함. RedisCacheConfig에서 정의한 캐시 매니저를 사용
+    )
     @GetMapping("/board/{board_id}/posts")
     public List<BoardDTO> getAllGeneralPost(@PathVariable Long board_id) {
         Board board = new Board();

--- a/src/main/java/com/ac/su/community/board/BoardController.java
+++ b/src/main/java/com/ac/su/community/board/BoardController.java
@@ -32,7 +32,7 @@ public class BoardController {
     // 동일한 인자로 호출될 때 캐시에서 결과를 가져옴
     @Cacheable(
             cacheNames = "getBoards", // 캐시의 이름. 다른 캐시와 구분하기 위해 사용됨
-            key = "'boards:type:' + #type", // 캐시의 키를 정의. 여기서는 페이지와 사이즈를 포함한 문자열로 키를 생성함
+            key = "'boards:board_id:' + #board_id", // 캐시의 키를 정의. 여기서는 페이지와 사이즈를 포함한 문자열로 키를 생성함
             cacheManager = "boardCacheManager" // 사용할 캐시 매니저를 지정함. RedisCacheConfig에서 정의한 캐시 매니저를 사용
     )
     @GetMapping("/board/{board_id}/posts")

--- a/src/main/java/com/ac/su/config/RedisCacheConfig.java
+++ b/src/main/java/com/ac/su/config/RedisCacheConfig.java
@@ -1,6 +1,8 @@
 package com.ac.su.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -25,7 +27,8 @@ public class RedisCacheConfig {
         ObjectMapper objectMapper = new ObjectMapper();
         // Java 8/17 Date/Time 타입 처리 모듈 등록
         objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.findAndRegisterModules(); // 자동 모듈 로드
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // 날짜를 ISO-8601 문자열로 직렬화
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL); // null 필드는 직렬화하지 않음
 
         // JSON 직렬화에 ObjectMapper를 전달하여 Jackson2JsonRedisSerializer 생성
         Jackson2JsonRedisSerializer<Object> jackson2JsonRedisSerializer = new Jackson2JsonRedisSerializer<>(objectMapper, Object.class);
@@ -47,3 +50,4 @@ public class RedisCacheConfig {
                 .build();
     }
 }
+

--- a/src/main/java/com/ac/su/config/RedisCacheConfig.java
+++ b/src/main/java/com/ac/su/config/RedisCacheConfig.java
@@ -1,0 +1,45 @@
+package com.ac.su.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration // 이 클래스가 Spring의 설정 클래스로 사용됨을 나타냄
+@EnableCaching // Spring의 캐시 기능을 활성화함
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager boardCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        // RedisCacheConfiguration 객체를 생성하여 Redis 캐시의 기본 설정을 정의함
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                // Redis에 저장할 키를 String 형태로 직렬화하여 저장하도록 설정
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()))
+                // Redis에 저장할 값을 JSON 형태로 직렬화하여 저장하도록 설정
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new Jackson2JsonRedisSerializer<Object>(Object.class)
+                        )
+                )
+                // 캐시에 저장된 데이터의 만료 시간을 1분으로 설정함
+                .entryTtl(Duration.ofMinutes(1L));
+
+        // RedisCacheManager는 캐시를 관리하는 객체로, 여기서 RedisConnectionFactory를 사용해
+        // Redis 서버에 연결하고, 위에서 정의한 RedisCacheConfiguration을 기본 설정으로 사용함
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/com/ac/su/config/RedisConfig.java
+++ b/src/main/java/com/ac/su/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.ac.su.config;
+
+// 이 클래스의 목적은 Redis와의 연결을 설정하는 것임
+// LettuceConnectionFactory는 Redis 서버와의 연결을 관리하며, 이 객체가 생성될 때 Redis 서버의 호스트와 포트 정보를 사용함
+// 이 설정을 통해 Spring Boot 애플리케이션이 Redis 서버에 연결할 수 있게됨
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration // 이 클래스가 Spring의 설정 클래스로 사용됨을 나타냄
+public class RedisConfig {
+    // application.properties 또는 application.yml 파일에서 설정한 값을 주입받음
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean // Spring 컨테이너에 이 메서드의 반환 객체를 Bean으로 등록함
+    public LettuceConnectionFactory redisConnectionFactory() {
+        // RedisStandaloneConfiguration 객체를 생성하여 Redis 서버의 호스트와 포트 정보를 설정
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(host, port);
+
+        // LettuceConnectionFactory는 Redis 서버와의 연결을 관리하는 객체로,
+        // Spring에서 Redis를 사용할 때 연결을 생성하고 관리하는 데 사용됨
+        return new LettuceConnectionFactory(redisConfig);
+    }
+}


### PR DESCRIPTION
24.08.23 redis 셋팅 게시글 불러올 때 캐싱 적용

/board/{board_id}/posts API 요청 시에 
캐싱을 적용하도록 코드를 수정하였습니다.

기존의 개시글을 불러올 때 평균 300ms에서 평균 5ms 성능 향상 효과가 있습니다(postman 기준)